### PR TITLE
Fix missing null terminator in VTX power label parser

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -3026,6 +3026,7 @@ static void cliVtxTable(const char *cmdName, char *cmdline)
         int count;
         for (count = 0; count < levels && (tok = strtok_r(NULL, " ", &saveptr)); count++) {
             strncpy(label[count], tok, VTX_TABLE_POWER_LABEL_LENGTH);
+            label[count][VTX_TABLE_POWER_LABEL_LENGTH] = '\0';
             for (unsigned i = 0; i < strlen(label[count]); i++) {
                 label[count][i] = toupper(label[count][i]);
             }


### PR DESCRIPTION
## Summary
- ensure `powerlabels` command in CLI always null-terminates label strings before processing

## Testing
- `make test` *(fails: unable to parse script file)*

------
https://chatgpt.com/codex/tasks/task_e_6845dddb8f84832fb368e71b1f28fffd